### PR TITLE
Show message when there are no tabs that have matching panels

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -192,6 +192,9 @@
         // Otherwise, remove tab from tabs collection
         } else {
           plugin.tabs = plugin.tabs.not($tab);
+          if ('console' in window) {
+            console.warn('Warning: tab without matching panel for selector \'#' + targetId +'\' removed from set');
+          }
         }
       });
     };


### PR DESCRIPTION
Background: I had a tab container that was too specific (it contained the tabs but not the panels). I was getting errors about easytabs not being able to find the default tab in the tab set. After inserting some console calls, I figured out that easytabs was removing all of my tabs because it couldn't find any matching panels. 

This pull request shows an error message in the console if easytabs can't find any tabs with matching panels in the tab container.
