### PR TITLE
Current extraction of the targetId from the href is broken if URL contains the current page URL before anchor

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -169,7 +169,7 @@
         } else {
           targetId = $a.attr('href');
         }
-        targetId = targetId.match(/#([^\?]+)/)[0].substr(1);
+        targetId = targetId.match(/#([^\?]+)/)[1];
 
         $matchingPanel = settings.panelContext.find("#" + targetId);
 


### PR DESCRIPTION
targetId should be found using the capturing group rather than the current way. This would work for all URLs while the current code is broken for href that include the page URL.

Currently if your href is something like :
href="thepage#anchor"

The library will use a targetId of "hepage#anchor" as it's taking into account the whole matched string and removing the first character.

This is not the correct behaviour, and the targetId should simply be anchor, which can be retrieved using the first matching group (index 1) rather than using this weird approach.
