### PR TITLE
Adding a refresh function

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -3,7 +3,7 @@
   <title>EasyTabs Demo</title>
   <script src="../vendor/jquery-1.7.1.min.js" type="text/javascript"></script> 
   <script src="../vendor/jquery.hashchange.min.js" type="text/javascript"></script>
-  <script src="../lib/jquery.easytabs.min.js" type="text/javascript"></script>
+  <script src="../lib/jquery.easytabs.js" type="text/javascript"></script>
 
   <style>
     /* Example Styles for Demo */
@@ -104,6 +104,14 @@ $('#tab-container').easytabs();
   </div>
  </div>
 </div>
-
+<button class='test'>Add a tab</button>
+<script type='text/javascript'>
+$(function() {
+$("button").click(function() {
+	var newTab = $("<li class='tab'><a href='#tabs4-test'>New tab</a></li>").appendTo($(".etabs"));
+	var newTabPane = $("<div id='tabs4-test'>Test</div>").appendTo($(".panel-container"));
+	$("#tab-container").easytabs("refresh");
+});
+});</script>
 </body>
 </html>

--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -139,6 +139,9 @@
           halfSpeed: 0
         };
     };
+	plugin.destroy = function() {
+		plugin.tabs.children("a").unbind(settings.bind_str);
+	};
 
     // Find and instantiate tabs and panels.
     // Could be used to reset tab and panel collection if markup is
@@ -151,7 +154,7 @@
       plugin.tabs = $container.find(settings.tabs),
 
       // Instantiate panels as empty jquery object
-      plugin.panels = $(),
+      plugin.panels = plugin.panels || $(),
 
       plugin.tabs.each(function(){
         var $tab = $(this),
@@ -162,7 +165,7 @@
             // `data-target` attribute for ajax tabs since the `href` is
             // the ajax URL
             targetId = $tab.children('a').data('target');
-
+		if ($tab.data("easytabs") !== undefined) return;
         $tab.data('easytabs', {});
 
         // If the tab has a `data-target` attribute, and is thus an ajax tab
@@ -344,6 +347,15 @@
 
     // Convenient public methods
     plugin.publicMethods = {
+	  refresh: function() {
+		plugin.getTabs();
+		addClasses();
+
+		setDefaultTab();
+
+		bindToTabClicks();
+		
+	  },
       select: function(tabSelector){
         var $tab;
 
@@ -470,7 +482,9 @@
     // Bind tab-select funtionality to namespaced click event, called by
     // init
     var bindToTabClicks = function() {
-      plugin.tabs.children("a").bind(settings.bind_str, function(e) {
+      plugin.tabs.children("a").each(function() {
+		if ($(this).data("easytab-cycled")) return;
+		$(this).bind(settings.bind_str, function(e) {
 
         // Stop cycling when a tab is clicked
         settings.cycle = false;
@@ -485,7 +499,8 @@
         // Don't follow the link to the anchor
         e.preventDefault ? e.preventDefault() : e.returnValue = false;
       });
-    };
+    });
+	}
 
     // Activate a given tab/panel, called from plugin.selectTab:
     //


### PR DESCRIPTION
The ability to add a tab to an already-running tabset is a nice feature.
I've just added it.

Syntax: $("#tab-container").easytabs("refresh");

Caveats:
- Hash change has a bit of a bug, fixing it at the moment.
