### PR TITLE
typo in valid id pattern

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -290,7 +290,7 @@
     // Make sure hash is a valid id value (admittedly strict in that HTML5 allows almost anything without a space)
     // but jQuery has issues with such id values anyway, so we can afford to be strict here.
     plugin.validId = function(id) {
-      return id.substr(1).match(/^[A-Za-z]+[A-Za-z0-9\-_:\.].$/);
+      return id.substr(1).match(/^[A-Za-z][A-Za-z0-9\-_:\.]*$/);
     };
 
     // Select matching tab when URL hash changes


### PR DESCRIPTION
currently reads, "one or more letters followed one letter, number or assorted symbols followed by one pretty much anything."
Because of this aaaCDCDDCD or a-$ matches but test-site does not.
To be a bit more clear on exactly what we want to capture saying, "one letter followed by zero or more letters, numbers or assorted symbols.
