### PR TITLE
Multiple panel content showing

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -580,7 +580,7 @@
         plugin.tabs.filter("." + settings.collapsedClass).removeClass(settings.collapsedClass).children().removeClass(settings.collapsedClass);
         $clicked.parent().addClass(settings.tabActiveClass).children().addClass(settings.tabActiveClass);
 
-        plugin.panels.filter("." + settings.panelActiveClass).removeClass(settings.panelActiveClass);
+        plugin.panels.filter("." + settings.panelActiveClass).removeClass(settings.panelActiveClass).hide();
         $targetPanel.addClass(settings.panelActiveClass);
 
         if( $visiblePanel.length ) {


### PR DESCRIPTION
When linking into a panel from another set of tabs via an anchor it was possible to see the default active panel as well as the panel your link was in. Hiding after removing the active class takes care of this problem. It also fixes the back button navigating to the default panel instead of back to the tab group you originally came from. Should fix #93
