### PR TITLE
Overflow bugfix

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -509,7 +509,8 @@
             visibleHeight,
             heightDifference,
             showPanel,
-            hash = window.location.hash.match(/^[^\?]*/)[0];
+            hash = window.location.hash.match(/^[^\?]*/)[0],
+            overflowSetting;
 
         if (settings.animate) {
           targetHeight = getHeightForHidden($targetPanel);
@@ -529,10 +530,13 @@
           // Gracefully animate between panels of differing heights, start height change animation *after* panel change if panel needs to contract,
           // so that there is no chance of making the visible panel overflowing the height of the target panel
           if (settings.animate && settings.transitionIn == 'fadeIn') {
-            if (heightDifference < 0)
-              $panelContainer.animate({
-                height: $panelContainer.height() + heightDifference
-              }, transitions.halfSpeed ).css({ 'min-height': '' });
+            if (heightDifference < 0) {
+                overflowSetting = $panelContainer.css('overflow');
+                $panelContainer.animate({
+                  height: $panelContainer.height() + heightDifference
+                }, transitions.halfSpeed ).css({ 'min-height': '' });
+                $panelContainer.css('overflow', overflowSetting);
+              }
           }
 
           if ( settings.updateHash && ! skipUpdateToHash ) {
@@ -566,9 +570,11 @@
         // so that there is no chance of making the target panel overflowing the height of the visible panel
         if( settings.animate && settings.transitionOut == 'fadeOut' ) {
           if( heightDifference > 0 ) {
+            overflowSetting = $panelContainer.css('overflow');
             $panelContainer.animate({
               height: ( $panelContainer.height() + heightDifference )
             }, transitions.halfSpeed );
+            $panelContainer.css('overflow', overflowSetting);
           } else {
             // Prevent height jumping before height transition is triggered at midTransition
             $panelContainer.css({ 'min-height': $panelContainer.height() });


### PR DESCRIPTION
On fadeIn/fadeOut animation the container's overflow parameter changes to hidden. This may cause problems (as it caused in my site :))

If you want to try this bug out, use this parameters:

``` javascript
$("#wrapper").easytabs({
        animate         : true,
        updateHash      : true,
        transitionIn    : 'fadeIn',
        transitionOut   : 'fadeOut',
        animationSpeed  : 500,
        tabActiveClass  : 'active'
    });
```

On this HTML:

``` html
<div id ="wrapper" class ="wrapper">
    <ul id ="navigation-menu" class ="navigation-menu">
        <li><a class ="profile" href="#profile"><span>Profile</span></a></li>
        <li><a class ="documents" href="#documents"><span>Documents</span></a></li>
    </ul>
    <div id ="container">
        <div id ="profile">
            asdf
        </div>
        <div id ="documents">
            asdf
        </div>
    </div>
</div>
```
