### PR TITLE
Update jquery.easytabs.js

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -76,8 +76,10 @@
 
       // Add jQuery UI's crazy class names to markup,
       // so that markup will match theme CSS
+      //note: In newer versions of jQueryUI (1.9+), `ui-tabs-selected` has been replaced with `ui-tabs-active`. 
+
       if ( settings.uiTabs ) {
-        settings.tabActiveClass = 'ui-tabs-selected';
+        settings.tabActiveClass = 'ui-tabs-active';
         settings.containerClass = 'ui-tabs ui-widget ui-widget-content ui-corner-all';
         settings.tabsClass = 'ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all';
         settings.tabClass = 'ui-state-default ui-corner-top';


### PR DESCRIPTION
In newer versions of jQueryUI (1.9+), `ui-tabs-selected` has been replaced with `ui-tabs-active`.
