### PR TITLE
Use history API fallback to location hash

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -538,7 +538,12 @@
           if ( settings.updateHash && ! skipUpdateToHash ) {
             //window.location = url.toString().replace((url.pathname + hash), (url.pathname + $clicked.attr("href")));
             // Not sure why this behaves so differently, but it's more straight forward and seems to have less side-effects
-            window.location.hash = '#' + $targetPanel.attr('id');
+						if (window.history.pushState) {
+							window.history.pushState(null, null, '#' + $targetPanel.attr('id'));
+						}
+						else {
+							window.location.hash = '#' + $targetPanel.attr('id');
+						}
           } else {
             skipUpdateToHash = false;
           }


### PR DESCRIPTION
this prevents the browser from jumping to the anchor identified by the hash
