### PR TITLE
fix main path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,5 @@
     }
   ],
   "homepage": "http://www.alfajango.com/blog/jquery-easytabs-plugin/",
-  "main": "/lib/jquery.easytabs.min.js"
+  "main": "./lib/jquery.easytabs.min.js"
 }


### PR DESCRIPTION
This allows browserify users to successfully install the package via

```
npm install JangoSteve/jQuery-EasyTabs
```

and in the js

``` js
require('EasyTabs');
```
