### PR TITLE
Fixed version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   ],
   "dependencies": {
-    "jquery": ["1.4.3","1.5","1.6","1.7","1.8","1.9","1.10"]
+    "jquery": "1.4.3 - 1.10"
   },
   "optionalDependencies": {
     "hashchange": "",


### PR DESCRIPTION
The version definition in package.json cannot be an array according to https://docs.npmjs.com/files/package.json
